### PR TITLE
Write the whole buffer to gocode tmpfile

### DIFF
--- a/autoload/asyncomplete/sources/gocode.vim
+++ b/autoload/asyncomplete/sources/gocode.vim
@@ -37,7 +37,7 @@ function! s:on_exec_events(info, id, data, event) abort
 endfunction
 
 function! s:write_buffer_to_tempfile(ctx) abort
-    let l:buf = getline(a:ctx['bufnr'], '$')
+    let l:buf = getline(1, '$')
     if &encoding !=? 'utf-8'
         let l:buf = map(l:buf, 'iconv(v:val, &encoding, "utf-8")')
     endif


### PR DESCRIPTION
When creating the temporary file from the current buffer, only the lines
starting at `bufnr` to the end of the file are included, causing a
number of lines to be skipped depending on the current buffer number.

The missing lines would cause a go parsing error on gocode, preventing
it from being able to identify the context of the cursor and therefore
provide possible completion suggestions.

Fixes https://github.com/prabirshrestha/asyncomplete-gocode.vim/issues/4